### PR TITLE
Update disposable_domains.txt

### DIFF
--- a/data/manual/disposable_domains.txt
+++ b/data/manual/disposable_domains.txt
@@ -1,0 +1,1 @@
+hutudns.com


### PR DESCRIPTION
### What

Add hutudns.com to disposable_domains

### Why

Had sign up from hutudns.com email but it was not blocked by this gem, since hutudns.com is not in disposable domains list.